### PR TITLE
prod and dev configs added to store setup

### DIFF
--- a/internal/odin/config/environment.go
+++ b/internal/odin/config/environment.go
@@ -62,7 +62,7 @@ type EnvConfig struct {
 	ODIN_USER_TOKEN  string `mapstructure:"ODIN_USER_TOKEN"`
 	ODIN_ADMIN_TOKEN string `mapstructure:"ODIN_ADMIN_TOKEN"`
 
-	RIPPKGS_URL string `mapstructure:"RIPPKGS_URL"`
+	RIPPKGS_BASE_URL string `mapstructure:"RIPPKGS_BASE_URL"`
 
 	ODIN_BASE_DIR string `mapstructure:"ODIN_BASE_DIR"`
 }
@@ -150,7 +150,7 @@ func setDefaults() {
 	viper.SetDefault("ODIN_LOG_LEVEL", "info")
 	viper.SetDefault("ODIN_WORKER_DOCKER_IMAGE", "odin:alpine")
 	viper.SetDefault("ODIN_WORKER_PODMAN_IMAGE", "odin:alpine")
-	viper.SetDefault("RIPPKGS_URL", "https://valnix-stage-bucket.s3.us-east-1.amazonaws.com/rippkgs-24.11.sqlite")
+	viper.SetDefault("RIPPKGS_BASE_URL", "https://valnix-stage-bucket.s3.us-east-1.amazonaws.com")
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/odin/store/store_config.dev.yml
+++ b/internal/odin/store/store_config.dev.yml
@@ -1,0 +1,234 @@
+nix_channel: 24.11
+
+languages:
+  - name: python
+    extension: py
+    monacoLanguage: python
+    versions:
+      - nixPackage: "python312"
+        searchQuery: "python312Packages"
+        default: true
+      - nixPackage: "python311"
+        searchQuery: "python311Packages"
+    template: |
+      {{ define "LangSetup" }}
+      {{- if .IsFlake -}}
+                ({{.LangNixPkg}}.withPackages (python-pkgs: [
+                  {{ range .LanguageDependencies -}}
+                    python-pkgs.{{.}}
+                  {{ end -}}
+                ]))
+      {{- else -}}
+      '{{.LangNixPkg}}.withPackages( p: [ {{ range .LanguageDependencies }} p.{{.}} {{ end }} ] )'
+      {{- end -}}
+      {{ end }}
+
+      {{  define "execute" }} python main.py {{ end }}
+    deps:
+      - requests
+      - numpy
+      - openai
+      - opencv4
+      - openllm
+      - openapi3
+      - openaiauth
+      - openapi-core
+      - openllm-client
+      - sshtunnel
+      - sslib
+      - mathlibtools
+      - random2
+      - stringly
+      - stringcase
+      - stringparser
+      - stringbrewer
+      - datauri
+      - datatable
+      - dataproperty
+      - html5lib
+      - html5tagger
+      - html-tag-names
+      - html-text
+      - beautifulsoup4
+      - selenium
+      - selenium-wire
+      - pandas
+      - scipy
+      - scikit-learn
+      - matplotlib
+      - tensorflow
+      - pytorch-lightning
+      - statsmodels
+      - nltk
+      - gensim
+      - openpyxl
+      - lxml
+      - sqlalchemy
+      - pyyaml
+      - pytest
+      - pydantic
+      # - asyncio
+      - regex
+      - tqdm
+      - jinja2
+      - attrs
+      - jsonschema
+      - cryptography
+      - cx-oracle
+      - pymongo
+      - h5py
+      - pytest-bdd
+      - fastparquet
+      - nltk
+      - langsmith
+      - anthropic
+      - huggingface-hub
+      - litellm
+      - llama-index-embeddings-huggingface
+      - fastai
+      - jax
+      - spacy
+      - lightgbm
+      - mxnet
+      - minichain
+      - langchain-core
+      - zulip
+      - prophet
+      - google-cloud-automl
+      - torchio
+      - orange3
+      - optuna
+      - onnx
+      - onnxruntime
+      - botorch
+      - accupy
+      - kornia
+      - ignite
+      - gym
+      - tensorly
+      - tensordict
+      - keras
+      - tensorflow
+      - gitpython
+      - gitdb
+
+    defaultCode: |
+      print("Hello World")
+
+  - name: go
+    extension: go
+    monacoLanguage: go
+    versions:
+      - nixPackage: "go_1_22"
+        searchQuery: "goPackages"
+    template: |
+      {{ define "compile" }} go build main.go {{ .CompilerArgs }}{{ end }}
+      {{ define "execute" }} ./main {{ end }}
+    defaultCode: |
+      package main
+      import "fmt"
+
+      func main() {
+          fmt.Println("Hello, World!")
+      }
+
+  - name: bash
+    extension: bash
+    monacoLanguage: shell
+    versions:
+      - nixPackage: "bash"
+        default: true
+        searchQuery: "bashPackages"
+    template: |
+      {{ define "execute" }} bash main.bash {{ end }}
+    defaultCode: |
+      echo hello
+
+  - name: bun
+    extension: js
+    monacoLanguage: javascript
+    versions:
+      - nixPackage: "bun"
+        default: true
+        searchQuery: "bunPackages"
+    template: |
+      {{ define "execute" }} bun run main.js {{ end }}
+    defaultCode: |
+      console.log("Hello World!")
+
+  - name: deno
+    extension: ts
+    monacoLanguage: typescript
+    versions:
+      - nixPackage: "deno"
+        default: true
+        searchQuery: "deno"
+    template: |
+      {{ define "execute" }} deno run main.ts {{ end }}
+    defaultCode: |
+      console.log("Hello World");
+
+  - name: node
+    extension: js
+    monacoLanguage: javascript
+    versions:
+      - nixPackage: "nodejs_22"
+        searchQuery: "nodePackages"
+      - nixPackage: "nodejs_20"
+        searchQuery: "nodePackages"
+      - nixPackage: "nodejs_18"
+        searchQuery: "nodePackages"
+      - nixPackage: "nodejs_23"
+        default: true
+        searchQuery: "nodePackages"
+    template: |
+      {{ define "execute" }} node main.js {{ end }}
+    defaultCode: |
+      console.log("Hello World!");
+    deps:
+      - lodash
+    
+  - name: rust
+    extension: rs
+    monacoLanguage: rust
+    versions:
+      - nixPackage: "rustc"
+        default: true
+        searchQuery: "rust"
+    template: |
+      {{ define "compile" }} rustc main.rs {{ .CompilerArgs }} {{ end }} 
+      {{ define "execute" }} ./main {{ end }}
+    defaultCode: |
+      fn main() {
+          println!("Hello, world!");
+      }
+
+  - name: sql
+    extension: sql
+    monacoLanguage: sql
+    versions:
+      - nixPackage: "sqlite"
+        default: true
+        searchQuery: "sql"
+    template: |
+      {{ define "execute" }} sqlite3 sample.db < main.sql {{ end }}
+    defaultCode: |
+      CREATE TABLE employees (
+          id INT PRIMARY KEY,
+          name VARCHAR(100),
+          salary DECIMAL(10, 2)
+      );
+
+packages:
+  - jq
+  - ffmpeg
+  - git
+  - gnumake
+  - gnused
+  - gnutar
+  - gzip
+  - curl
+  - wget
+  - bzip2
+  - sqlite
+  - gcc14

--- a/internal/odin/store/store_config.prod.yml
+++ b/internal/odin/store/store_config.prod.yml
@@ -1,4 +1,4 @@
-nix_channel: https://nixos.org/channels/nixos-24.11
+nix_channel: 24.11
 
 languages:
   - name: python


### PR DESCRIPTION
Store now has two configs dev and prod this was done so that users can easily setup odin without having to download a ton of dependencies and the load on nixos cache gets reduced